### PR TITLE
Moves cli.py to driloader module

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,10 +54,9 @@ browser.quit()
 
 ## CLI and standalone usage
 ```bash
-chmod +x cli.py
-./cli.py -h
+python -m driloader
 
-usage: cli.py [-h] (--firefox | --chrome | --internet-explorer | --all)
+usage: driloader [-h] (--firefox | --chrome | --internet-explorer | --all)
 
 optional arguments:
   -h, --help            show this help message and exit
@@ -69,25 +68,25 @@ optional arguments:
 ```
 ### Retrieve Firefox version
 ```bash
-$  ./cli.py --firefox
+$  python -m driloader --firefox
 45
 ```
 
 ### Retrieve Google Chrome version
 ```bash
-$  ./cli.py --chrome
+$  python -m driloader --chrome
 58
 ```
 
 ### Retrieve Internet Explorer version (Windows system)
 ```cmd
-> cli.py -i
+> python -m driloader -i
 11
 ```
 
 ### Retrieve all browsers version (Windows system)
 ```bash
-> cli.py --all
+> python -m driloader --all
 Internet Explorer: 11
 Firefox: 45
 Google Chrome: 58
@@ -97,7 +96,7 @@ Google Chrome: 58
 ### Retrieve all browsers version (non-Windows system)
 ```bash
 # Getting from a non-Windows system
-$  ./cli.py --all
+$  python -m driloader --all
 Internet Explorer: Error: Unable to get the Internet Explorer version.
         Cause: Error: Unable to retrieve IE version..
         Cause: System is not Windows.

--- a/driloader/__main__.py
+++ b/driloader/__main__.py
@@ -12,7 +12,7 @@
 import sys
 import argparse
 
-from driloader.browser_detection import BrowserDetection, BrowserDetectionError
+from .browser_detection import BrowserDetection, BrowserDetectionError
 
 
 class OutputType():
@@ -132,7 +132,7 @@ def parse_args():
         None
     """
 
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(prog="driloader")
     action = parser.add_mutually_exclusive_group(required=True)
     action.add_argument('--firefox', '-f',
                         help='get Firefox version.',


### PR DESCRIPTION
Moves `cli.py` to driloader module as `__main__.py`, so it can be called as `python -m driloader`