### PR TITLE
Changes lint minimum score from 9.5 to 10

### DIFF
--- a/lint.py
+++ b/lint.py
@@ -2,12 +2,12 @@ import sys
 
 from pylint.lint import Run
 
-min_score = 9.5
+min_score = 10
 
 results = Run(['driloader', 'tests'], exit=False)
 global_note = results.linter.stats['global_note']
 
-if global_note > min_score:
+if global_note >= min_score:
     print('Minimum score reached! min_score = {}'.format(str(min_score)))
 else:
     print('Minimum score not reached! min_score = {}'.format(str(min_score)))

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 setup(
     name='driloader',
     version='1.1.7',
-    packages=find_packages(),
+    packages=find_packages(exclude=['tests', '*.tests', '*.tests.*']),
     include_package_data=True,
     description='Driver downloader for Selenium',
     author='Lucas Trajano;Felipe Viegas;Jonatha Daguerre',


### PR DESCRIPTION
Since we reached score 10/10 in pylint, there is no motive for not keeping it. So, this PR changes the lint minimum score from 9.5 to 10.

Also the `tests` folder has been excluded from dist package generation.