### PR TITLE
Fixes long description for PyPI and adds upload tasks in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
-# Used when make is called with no target
 default: help
+
+upgrade-dist-tools:
+	python -m pip install --upgrade setuptools wheel twine
 
 # Install packages from Pipfile
 install:
@@ -19,19 +21,28 @@ lint:
 	python lint.py
 
 
-# Create egg from source
-build:
-	python setup.py install
+# Create wheel from source
+build: upgrade-dist-tools
+	python setup.py sdist bdist_wheel
 
 
 # Remove build files
 clean:
-	rm -rf build/ driloader.egg-info/
-
+	rm -rf build/ driloader.egg-info/ dist/
 
 # Sort imports as PEP8
 isort:
 	isort **/*.py
+
+
+# Upload dist content to test.pypi.org
+upload-test:
+	twine upload --repository-url https://test.pypi.org/legacy/ dist/*
+
+
+# Upload dist content to pypi.org
+upload:
+	twine upload  dist/*
 
 
 # Display this help
@@ -39,7 +50,7 @@ help:
 	@ echo
 	@ echo '  Usage:'
 	@ echo ''
-	@ echo '	make <target> [flags...]'
+	@ echo '	make <target>'
 	@ echo ''
 	@ echo '  Targets:'
 	@ echo ''

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,0 @@
-[metadata]
-description-file = README.md

--- a/setup.py
+++ b/setup.py
@@ -1,13 +1,18 @@
 from setuptools import setup, find_packages
 
+with open("README.md", "r") as fh:
+    long_description = fh.read()
+
 setup(
     name='driloader',
-    version='1.1.7',
+    version='1.2.1',
     packages=find_packages(exclude=['tests', '*.tests', '*.tests.*']),
     include_package_data=True,
     description='Driver downloader for Selenium',
-    author='Lucas Trajano;Felipe Viegas;Jonatha Daguerre',
+    author='Lucas Trajano; Felipe Viegas; Jonatha Daguerre',
     license='MIT',
+    long_description=long_description,
+    long_description_content_type="text/markdown",
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Developers',


### PR DESCRIPTION
1. Fixes long description for PyPI page https://pypi.org/project/Driloader/

2. Adds upload tasks in Makefile:
```
upload-test   Upload dist content to test.pypi.org
upload        Upload dist content to pypi.org
```

3. Improves task build:
`build        Create wheel from source`
